### PR TITLE
preserve options.selector setting

### DIFF
--- a/public/validator.js
+++ b/public/validator.js
@@ -359,6 +359,7 @@
 
 						var valid;
 
+						var origSelector = options.selector;
 						options.selector = options.selector || this;
 
 						valid = validations.validate(options);
@@ -370,6 +371,8 @@
 						if (options.done) {
 							options.done(valid);
 						}
+						
+						options.selector = origSelector;
 
 					});
 


### PR DESCRIPTION
This fixes a bug with the  $('input').validator({...}) usage suggested in the readme.

When the first input was validated on blur, options.selector was set to that input via `options.selector = options.selector || this;`. When a second input was validated, options.selector was still set to the first input, so the first input was re-validated instead of the second input.

My fix was to reset options.selector to the explicit setting after validations.validate(options) was done.
